### PR TITLE
Detach plugin when we start receiving audio/video false

### DIFF
--- a/lib/janus/session.ex
+++ b/lib/janus/session.ex
@@ -136,6 +136,9 @@ defmodule Janus.Session do
                   %{janus: "webrtcup"} -> Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:webrtcup, pid, plugin_pid}))
                   %{janus: "media", type: type, receiving: receiving} ->
                     Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:media, pid, plugin_pid, type, receiving}))
+                    if (receiving == false) do
+                      Janus.Plugin.detach(plugin_pid)
+                    end
                   %{janus: "slowlink", uplink: uplink, nacks: nacks} ->
                     Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:slowlink, pid, plugin_pid, uplink, nacks}))
                   %{janus: "hangup"} ->


### PR DESCRIPTION
Opening this PR just for discussion. When we start receiving audio/video false, I am sending detach for plugin from here. Why? because, I somehow don't receive audio/video receiving false event in plugin callback module's handle event. Though I see we have sent this event
```
 Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:media, pid, plugin_pid, type, receiving}))
```

What I do is just close the tab on a publisher, I get this event captured in elixir-janus plugin code, but not actual plugin module handle_event callback? Do you see any issue why we are not able to capture event in application code?

Thanks