### PR TITLE
[Only review purpose, don't merge] Changes for supporting stickiness for load balancers

### DIFF
--- a/lib/janus.ex
+++ b/lib/janus.ex
@@ -1,7 +1,6 @@
 import Janus.Util
 
 defmodule Janus do
-
   @moduledoc """
   This library is a client for the [Janus REST API](https://janus.conf.meetecho.com/docs/rest.html).
   """
@@ -10,6 +9,5 @@ defmodule Janus do
   Retrieves details on the Janus server located at `url`
   """
 
-  def info(url), do: get("#{url}/info")
-
+  def info(url), do: get("#{url}/info", "")
 end

--- a/lib/janus/plugin.ex
+++ b/lib/janus/plugin.ex
@@ -33,6 +33,12 @@ defmodule Janus.Plugin do
     post(plugin.base_url, plugin.cookie, maybe_add_key(msg, :jsep, jsep))
   end
 
+  def check_room_exists(plugin_base_url, body, cookie) do
+    msg = %{body: body, janus: "message"}
+
+    post(plugin_base_url, cookie, msg)
+  end
+
   def create(plugin_base_url, body, cookie) do
     msg = %{body: body, janus: "message"}
     post(plugin_base_url, cookie, msg)

--- a/lib/janus/plugin.ex
+++ b/lib/janus/plugin.ex
@@ -21,10 +21,14 @@ defmodule Janus.Plugin do
   def message(pid, body, jsep \\ nil) do
     plugin = Agent.get(pid, & &1)
 
+    IO.inspect("~~~ see body ": body)
+
     body =
       if body.request == "join" or body.request == "start" or body.request == "exists" do
+        IO.inspect("~~~ in if ": body.request)
         maybe_add_key(body, :room, plugin.room_number)
       else
+        IO.inspect("~~~ in else ": body.request)
         body
       end
 

--- a/lib/janus/plugin.ex
+++ b/lib/janus/plugin.ex
@@ -20,13 +20,16 @@ defmodule Janus.Plugin do
 
   def message(pid, body, jsep \\ nil) do
     plugin = Agent.get(pid, & &1)
+
+    body =
+      if body.request == "join" or body.request == "start" or body.request == "exists" do
+        maybe_add_key(body, :room, plugin.room_number)
+      else
+        body
+      end
+
     msg = %{body: body, janus: "message"}
 
-    if body and body.request == "join" and body.request == "start" and body.request == "exists" do
-      msg = maybe_add_key(msg, :room, plugin.room_number)
-    end
-
-    IO.inspect("Sending Janus message": msg)
     post(plugin.base_url, plugin.cookie, maybe_add_key(msg, :jsep, jsep))
   end
 

--- a/lib/janus/session.ex
+++ b/lib/janus/session.ex
@@ -100,7 +100,7 @@ defmodule Janus.Session do
 
           room_number = ConCache.get(:room_number_cache, room_name)
 
-          if room_number != nil do
+          room_number = if room_number != nil do
             room_number =
               case Janus.Plugin.check_room_exists(
                      plugin_base_url,
@@ -121,10 +121,10 @@ defmodule Janus.Session do
                   nil
               end
           else
-            room_number = nil
+            nil
           end
 
-          if room_number == nil do
+          plugin = if room_number == nil do
             IO.puts("Creating new Janus room")
 
             {:ok, response, _cookie} =
@@ -149,7 +149,7 @@ defmodule Janus.Session do
 
             ConCache.put(:room_number_cache, room_name, room_number)
 
-            plugin = %Janus.Plugin{
+            %Janus.Plugin{
               id: id,
               base_url: plugin_base_url,
               event_manager: event_manager,
@@ -159,7 +159,7 @@ defmodule Janus.Session do
           else
             IO.puts("Using existing Janus room")
 
-            plugin = %Janus.Plugin{
+            %Janus.Plugin{
               id: id,
               base_url: plugin_base_url,
               event_manager: event_manager,

--- a/lib/janus/session.ex
+++ b/lib/janus/session.ex
@@ -3,7 +3,6 @@ require Logger
 import Janus.Util
 
 defmodule Janus.Session do
-
   @moduledoc """
   Sessions are connections to the Janus server to which plugins are attached, and from which events are retrieved.
   """
@@ -13,6 +12,7 @@ defmodule Janus.Session do
     :id,
     :base_url,
     :event_manager,
+    :cookie,
     handles: %{}
   ]
 
@@ -23,18 +23,32 @@ defmodule Janus.Session do
   Use this function if you must perform additional configuration steps before the session is started.
   """
 
-  def init(url) do
-    case post(url, %{janus: :create}) do
-      {:ok, body} ->
+  def init(url, room_name, initial_cookie) do
+    case post(url, initial_cookie, %{janus: :create}) do
+      {:ok, body, new_cookie} ->
+        if new_cookie != nil do
+          ConCache.put(:room_cache, room_name, new_cookie)
+        else
+          # If new cookie is nil .. take it from cache
+          new_cookie = ConCache.get(:room_cache, room_name)
+
+          IO.inspect("init::cookie from cache.. should never be nil": new_cookie)
+        end
+
         id = body.data.id
         {:ok, event_manager} = GenEvent.start_link()
+
         session = %Janus.Session{
           id: id,
           base_url: "#{url}/#{id}",
-          event_manager: event_manager
+          event_manager: event_manager,
+          cookie: new_cookie
         }
+
         Agent.start(fn -> session end)
-      v -> v
+
+      v ->
+        v
     end
   end
 
@@ -42,12 +56,17 @@ defmodule Janus.Session do
 
   def start(pid) when is_pid(pid), do: poll(pid)
 
-  def start(url) do
-    case init(url) do
+  def start(url, room_name) do
+    # Get cookie for this room name if already exists
+    cookie = ConCache.get(:room_cache, room_name)
+
+    case init(url, room_name, cookie) do
       {:ok, pid} ->
         start(pid)
         {:ok, pid}
-      v -> v
+
+      v ->
+        v
     end
   end
 
@@ -61,97 +80,177 @@ defmodule Janus.Session do
   """
 
   def attach_plugin(pid, id) do
-    base_url = Agent.get(pid, &(&1.base_url))
-    v = case post(base_url, %{janus: :attach, plugin: id}) do
-      {:ok, body} ->
-        id = body.data.id
-        {:ok, event_manager} = GenEvent.start_link()
-        plugin = %Janus.Plugin{
-          id: id,
-          base_url: "#{base_url}/#{id}",
-          event_manager: event_manager
-        }
-        {:ok, plugin_pid} = Agent.start(fn -> plugin end)
-        Agent.update pid, fn(session) ->
-          new_handles = Map.put(session.handles, id, plugin_pid)
-          %{ session | handles: new_handles}
-        end
-        {:ok, plugin_pid}
-      v -> v
-    end
+    base_url = Agent.get(pid, & &1.base_url)
+
+    # get cookie
+    main_cookie = Agent.get(pid, & &1.cookie)
+
+    IO.inspect("attach_plugin:: main cookie - should never be nil": main_cookie)
+
+    v =
+      case post(base_url, main_cookie, %{janus: :attach, plugin: id}) do
+        {:ok, body, cookie} ->
+          id = body.data.id
+          {:ok, event_manager} = GenEvent.start_link()
+
+          plugin = %Janus.Plugin{
+            id: id,
+            base_url: "#{base_url}/#{id}",
+            event_manager: event_manager,
+            cookie: main_cookie
+          }
+
+          {:ok, plugin_pid} = Agent.start(fn -> plugin end)
+
+          Agent.update(pid, fn session ->
+            new_handles = Map.put(session.handles, id, plugin_pid)
+            %{session | handles: new_handles}
+          end)
+
+          {:ok, plugin_pid}
+
+        v ->
+          v
+      end
+
     v
   end
 
   @doc "Destroys the session, detaching all plugins, and freeing all allocated resources."
 
   def destroy(pid) do
-    base_url = Agent.get(pid, &(&1.base_url))
-    plugin_pids = Agent.get(pid, &(&1.handles)) |> Map.values()
-    Enum.each (plugin_pids), &(Janus.Plugin.detach(&1))
+    base_url = Agent.get(pid, & &1.base_url)
+    cookie = Agent.get(pid, & &1.base_url)
+
+    IO.inspect("destroy..  cookie.. should never be nil ": cookie)
+
+    plugin_pids = Agent.get(pid, & &1.handles) |> Map.values()
+    Enum.each(plugin_pids, &Janus.Plugin.detach(&1))
     Agent.stop(pid)
-    post(base_url, %{janus: :destroy})
+    post(base_url, cookie, %{janus: :destroy})
   end
 
   @doc "See `GenEvent.add_handler/3`."
-  def add_handler(session, handler, args), do: Agent.get session, &(GenEvent.add_handler(&1.event_manager, handler, args))
+  def add_handler(session, handler, args),
+    do: Agent.get(session, &GenEvent.add_handler(&1.event_manager, handler, args))
 
   @doc "See `GenEvent.add_mon_handler/3`."
-  def add_mon_handler(session, handler, args), do: Agent.get session, &(GenEvent.add_mon_handler(&1.event_manager, handler, args))
+  def add_mon_handler(session, handler, args),
+    do: Agent.get(session, &GenEvent.add_mon_handler(&1.event_manager, handler, args))
 
   @doc "See `GenEvent.call/4`."
-  def call(session, handler, timeout, request \\ 5000), do: Agent.get session, &(GenEvent.call(&1.event_manager, handler, request, timeout))
+  def call(session, handler, timeout, request \\ 5000),
+    do: Agent.get(session, &GenEvent.call(&1.event_manager, handler, request, timeout))
 
   @doc "See `GenEvent.remove_handler/3`."
-  def remove_handler(session, handler, args), do: Agent.get session, &(GenEvent.remove_handler(&1.event_manager, handler, args))
+  def remove_handler(session, handler, args),
+    do: Agent.get(session, &GenEvent.remove_handler(&1.event_manager, handler, args))
 
   @doc "See `GenEvent.stream/2`."
-  def stream(session, options \\ []), do: Agent.get session, &(GenEvent.stream(&1.event_manager, options))
+  def stream(session, options \\ []),
+    do: Agent.get(session, &GenEvent.stream(&1.event_manager, options))
 
   @doc "See `GenEvent.swap_handler/5`."
-  def swap_handler(session, handler1, args1, handler2, args2), do: Agent.get session, &(GenEvent.swap_handler(&1.event_manager, handler1, args1, handler2, args2))
+  def swap_handler(session, handler1, args1, handler2, args2),
+    do:
+      Agent.get(
+        session,
+        &GenEvent.swap_handler(&1.event_manager, handler1, args1, handler2, args2)
+      )
 
   @doc "See `GenEvent.swap_mon_handler/5`."
-  def swap_mon_handler(session, handler1, args1, handler2, args2), do: Agent.get session, &(GenEvent.swap_mon_handler(&1.event_manager, handler1, args1, handler2, args2))
+  def swap_mon_handler(session, handler1, args1, handler2, args2),
+    do:
+      Agent.get(
+        session,
+        &GenEvent.swap_mon_handler(&1.event_manager, handler1, args1, handler2, args2)
+      )
 
   @doc "See `GenEvent.which_handlers/1`."
-  def which_handlers(session), do: Agent.get session, &(GenEvent.which_handlers(&1.event_manager))
+  def which_handlers(session), do: Agent.get(session, &GenEvent.which_handlers(&1.event_manager))
 
   defp poll(pid) do
-    session = Agent.get pid, &(&1)
-    spawn fn ->
-      case get(session.base_url) do
-        {:ok, data} ->
+    session = Agent.get(pid, & &1)
+
+    spawn(fn ->
+      case get(session.base_url, session.cookie) do
+        {:ok, data, cookie} ->
           event_manager = session.event_manager
+
           case data do
-            %{janus: "keepalive"} -> GenEvent.notify(event_manager, {:keepalive, pid})
+            %{janus: "keepalive"} ->
+              GenEvent.notify(event_manager, {:keepalive, pid})
+
             %{sender: sender} ->
               # Refetch the session in case we've added new plugins while this poll was in flight.
-              session = Agent.get pid, &(&1)
+              session = Agent.get(pid, & &1)
               plugin_pid = session.handles[sender]
+
               if plugin_pid do
                 case data do
                   %{janus: "event", plugindata: plugindata} ->
                     jsep = data[:jsep]
-                    Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:event, pid, plugin_pid, plugindata.data, jsep}))
-                  %{janus: "webrtcup"} -> Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:webrtcup, pid, plugin_pid}))
+
+                    Agent.get(
+                      plugin_pid,
+                      &GenEvent.notify(
+                        &1.event_manager,
+                        {:event, pid, plugin_pid, plugindata.data, jsep}
+                      )
+                    )
+
+                  %{janus: "webrtcup"} ->
+                    Agent.get(
+                      plugin_pid,
+                      &GenEvent.notify(&1.event_manager, {:webrtcup, pid, plugin_pid})
+                    )
+
                   %{janus: "media", type: type, receiving: receiving} ->
-                    Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:media, pid, plugin_pid, type, receiving}))
+                    Agent.get(
+                      plugin_pid,
+                      &GenEvent.notify(
+                        &1.event_manager,
+                        {:media, pid, plugin_pid, type, receiving}
+                      )
+                    )
+
                   %{janus: "slowlink", uplink: uplink, nacks: nacks} ->
-                    Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:slowlink, pid, plugin_pid, uplink, nacks}))
+                    Agent.get(
+                      plugin_pid,
+                      &GenEvent.notify(
+                        &1.event_manager,
+                        {:slowlink, pid, plugin_pid, uplink, nacks}
+                      )
+                    )
+
                   %{janus: "hangup"} ->
                     reason = data[:reason]
-                    Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:hangup, pid, plugin_pid, reason}))
+
+                    Agent.get(
+                      plugin_pid,
+                      &GenEvent.notify(&1.event_manager, {:hangup, pid, plugin_pid, reason})
+                    )
+
                   %{janus: "detached"} ->
-                    Agent.get plugin_pid, &(GenEvent.notify(&1.event_manager, {:detached, pid, plugin_pid}))
+                    Agent.get(
+                      plugin_pid,
+                      &GenEvent.notify(&1.event_manager, {:detached, pid, plugin_pid})
+                    )
                 end
               end
-            _ -> nil
-          end
-          poll(pid)
-        {:error, reason} -> Logger.error(reason)
-        {:error, :invalid, _} -> nil
-      end
-    end
-  end
 
+            _ ->
+              nil
+          end
+
+          poll(pid)
+
+        {:error, reason} ->
+          Logger.error(reason)
+
+        {:error, :invalid, _} ->
+          nil
+      end
+    end)
+  end
 end

--- a/lib/janus/session.ex
+++ b/lib/janus/session.ex
@@ -100,6 +100,30 @@ defmodule Janus.Session do
 
           room_number = ConCache.get(:room_number_cache, room_name)
 
+          if room_number != nil do
+            room_number =
+              case Janus.Plugin.check_room_exists(
+                     plugin_base_url,
+                     %{
+                       request: "exists",
+                       room: room_number
+                     },
+                     main_cookie
+                   ) do
+                {:ok, %{janus: "success", plugindata: %{data: %{exists: true}}}, _cookie} ->
+                  room_number
+
+                {:ok, %{janus: "success", plugindata: %{data: %{exists: false}}}, _cookie} ->
+                  nil
+
+                _ ->
+                  Logger.error("Invalid request")
+                  nil
+              end
+          else
+            room_number = nil
+          end
+
           if room_number == nil do
             IO.puts("Creating new Janus room")
 

--- a/lib/janus/session.ex
+++ b/lib/janus/session.ex
@@ -120,7 +120,7 @@ defmodule Janus.Session do
 
   def destroy(pid) do
     base_url = Agent.get(pid, & &1.base_url)
-    cookie = Agent.get(pid, & &1.base_url)
+    cookie = Agent.get(pid, & &1.cookie)
 
     IO.inspect("destroy..  cookie.. should never be nil ": cookie)
 

--- a/lib/janus/util.ex
+++ b/lib/janus/util.ex
@@ -1,45 +1,75 @@
 require Logger
 
 defmodule Janus.Util do
-
   @moduledoc false
 
-  def get(url) do
+  def get(url, cookie) do
     Logger.debug("GET #{url}")
-    case HTTPoison.get(url, [], recv_timeout: :infinity) do
-      {:ok, %HTTPoison.Response{body: body}} ->
+
+    headers =
+      if cookie do
+        [{"Cookie", cookie}]
+      else
+        []
+      end
+
+    options = [{:recv_timeout, :infinity}]
+
+    case HTTPoison.get(url, headers, options) do
+      {:ok, %HTTPoison.Response{body: body, headers: headers}} ->
         case Poison.decode(body, keys: :atoms) do
           {:ok, %{janus: "error", error: error}} ->
             Logger.error(error.reason)
             {:error, error.reason}
+
           {:error, error} ->
             Logger.error(error)
             {:error, error}
+
           {:ok, v} ->
+            cookie = get_cookie_from_headers(headers)
+
             Logger.debug(inspect(v))
-            {:ok, v}
+            {:ok, v, cookie}
         end
+
       {:error, %HTTPoison.Error{reason: reason}} ->
         Logger.error(reason)
         {:error, reason}
     end
   end
 
-  def post(url, body) do
+  def post(url, cookie, body) do
     Logger.debug("POST #{url} (#{inspect(body)})")
-    case HTTPoison.post(url, Poison.encode!(add_transaction_id(body))) do
-      {:ok, %HTTPoison.Response{body: body}} ->
+
+    headers =
+      if cookie do
+        [{"Cookie", cookie}]
+      else
+        []
+      end
+
+    case HTTPoison.post(
+           url,
+           Poison.encode!(add_transaction_id(body)),
+           headers
+         ) do
+      {:ok, %HTTPoison.Response{body: body, headers: headers}} ->
         case Poison.decode(body, keys: :atoms) do
           {:ok, %{janus: "error", error: error}} ->
             Logger.error(error.reason)
             {:error, error.reason}
+
           {:error, error} ->
             Logger.error(error)
             {:error, error}
+
           {:ok, v} ->
+            cookie = get_cookie_from_headers(headers)
             Logger.debug(inspect(v))
-            {:ok, v}
+            {:ok, v, cookie}
         end
+
       {:error, %HTTPoison.Error{reason: reason}} ->
         Logger.error(reason)
         {:error, reason}
@@ -49,7 +79,7 @@ defmodule Janus.Util do
   def maybe_add_key(map, _key, nil), do: map
   def maybe_add_key(map, key, value), do: Map.put(map, key, value)
 
-  defp transaction_id, do: :rand.uniform(1000000000) |> to_string
+  defp transaction_id, do: :rand.uniform(1_000_000_000) |> to_string
 
   defp add_transaction_id(body) do
     case Map.get(body, :transaction) do
@@ -58,4 +88,18 @@ defmodule Janus.Util do
     end
   end
 
+  defp get_cookie_from_headers(headers) do
+    cookies =
+      Enum.filter(headers, fn
+        {"Set-Cookie", _} -> true
+        _ -> false
+      end)
+
+    if cookies != [] do
+      cookie = List.first(cookies)
+      elem(cookie, 1)
+    else
+      nil
+    end
+  end
 end


### PR DESCRIPTION
Hi @ndarilek 

I had to these changes for supporting stickiness. Janus can't be clustered for a videoroom, all participants of a video room need to connect to the same instance. 

So to solve this problem, I had to store the cookie in an in-memory cache and then pass it in subsequent requests for that particular room WebRTC in Janus.

P.S. I am also using a third party library named ConCache (https://github.com/sasa1977/con_cache) which I have not added in mix.exs here.. but my Phoenix app has it as a dependency.

Do you have any inputs .. if this can be improved much better than this? 

Thanks!


